### PR TITLE
Components usage template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3228,9 +3228,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001570",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001570.tgz",
-      "integrity": "sha512-+3e0ASu4sw1SWaoCtvPeyXp+5PsjigkSt8OXZbF9StH5pQWbxEjLAZE3n8Aup5udop1uRiKA7a4utUk/uoSpUw==",
+      "version": "1.0.30001617",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001617.tgz",
+      "integrity": "sha512-mLyjzNI9I+Pix8zwcrpxEbGlfqOkF9kM3ptzmKNw5tizSyYwMe+nGLTqMK9cO+0E+Bh6TsBxNAaHWEM8xwSsmA==",
       "dev": true,
       "funding": [
         {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,8 +4,7 @@ import React, { useCallback, useState } from 'react';
 import type { ButtonHTMLAttributes } from 'react';
 import { Link, Outlet } from 'react-router-dom';
 
-import { Button } from '../exports';
-import { ReactComponent as Logo } from '../icons/logo.svg';
+import { Button, Logo } from '../exports';
 import { getCombinedClass } from '../utils/getCombinedClass';
 
 import { MOBILE_ONLY_LOGO_AND_TITLE_ID } from './constants';


### PR DESCRIPTION
* New way to import and use svg files
* Eslint version upgrade
* Introduced withThemeSelector prop in StickyHeader
* Created new repo *static_assets* to host static assets from
* Created useHighlightCode hook and used
* Written JsDoc for all components with props and usage example
* Updated the copyright year
* Create new route for Switch component
* Memoized all the components