### PR TITLE
copyToClipboard with status & message, call callback passed

### DIFF
--- a/src/utils/copyToClipboard.ts
+++ b/src/utils/copyToClipboard.ts
@@ -1,20 +1,28 @@
 import { toast } from '../exports';
 
-export async function copyToClipboard(text = ''){
+export async function copyToClipboard(
+	text = ''
+): Promise<{ success: true; error: null } | { success: false; error: string }> {
 	try {
 		await window.navigator.clipboard.writeText(text);
 		toast.success('Copied !', {
 			closeAfter  : 2,
 			closeButton : { showCloseIcon: false },
-			timerStrip  : { showTimerStrip: false }
+			timerStrip  : { showTimerStrip: false },
 		});
-		return true;
-	} catch {
+		return {
+			success : true,
+			error   : null,
+		};
+	} catch (e) {
 		toast.error('! Could not copy !', {
 			closeAfter  : 2,
 			closeButton : { showCloseIcon: false },
-			timerStrip  : { showTimerStrip: false }
-		})
-		return false;
+			timerStrip  : { showTimerStrip: false },
+		});
+		return {
+			success : false,
+			error   : e instanceof Error ? e.message : 'Unknown error',
+		};
 	}
 }


### PR DESCRIPTION
# Description
Added callback props for copy to clipboard success or failure
For success call the onCopy callback received from props
For failure call the onCopyFail callback received from props with errorMessage as argument

# Screenshots (If any)
No visual UI change.

## Type of change
Please mark checked the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which add functionality)
- [ ] Breaking change (fix or feature that could cause existing functionality to not work as expected)
- [ ] Architecture improvements (which includes new feature addition to architecture or upgrading packages)
